### PR TITLE
refactor: rework Clone view file assets and profile sync

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -47,6 +47,7 @@ target_sources(${PLUGIN_NAME} PRIVATE
     Src/Components/FormFields/FormSliderField.cpp
     Src/Components/FormFields/FormTextField.cpp
     Src/Components/FormFields/FormToggleField.cpp
+    Src/Components/FileStatusCard.cpp
     Src/Components/ModalOverlay.cpp
     Src/Components/NotificationBanner.cpp
     Src/Modules/AddProfilModule.cpp
@@ -57,6 +58,7 @@ target_sources(${PLUGIN_NAME} PRIVATE
     Src/Modules/DeleteProfileConfirmationModule.cpp
     Src/Modules/EditProfilModule.cpp
     Src/Modules/ExportProfilModule.cpp
+    Src/Modules/FileAssetsModule.cpp
     Src/Modules/MasterSlidersModule.cpp
     Src/Modules/UtilityBarModule.cpp
     Src/Views/CloneView.cpp

--- a/Source/Include/Components/FileStatusCard.h
+++ b/Source/Include/Components/FileStatusCard.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <JuceHeader.h>
+
+#include "Components/CustomTextButton.h"
+#include "Stylesheet.h"
+
+class FileStatusCard : public juce::Component {
+   public:
+    struct Options {
+        juce::String title;
+        juce::String loadButtonText;
+        juce::String unloadButtonText{"Unload"};
+        juce::String emptyFileText;
+        juce::String emptyPathText;
+        ProfilerStyle::Theme loadButtonTheme = ProfilerStyle::Theme::Dark;
+        ProfilerStyle::Theme unloadButtonTheme = ProfilerStyle::Theme::Darker;
+    };
+
+    explicit FileStatusCard(Options options);
+    ~FileStatusCard() override = default;
+
+    void setFileState(bool isLoaded, const juce::File& file);
+
+    std::function<void()> onLoadClicked;
+    std::function<void()> onUnloadClicked;
+
+    void paint(juce::Graphics& g) override;
+    void resized() override;
+
+   private:
+    Options _options;
+    CustomTextButton _loadButton;
+    CustomTextButton _unloadButton;
+    juce::Label _titleLabel;
+    juce::Label _statusLabel;
+    juce::Label _fileLabel;
+    juce::Label _pathLabel;
+    juce::File _file;
+    bool _isLoaded = false;
+
+    void configureLabel(juce::Label& label,
+                        const juce::String& text,
+                        float fontSize,
+                        juce::Colour textColour,
+                        juce::Justification justification = juce::Justification::centredLeft,
+                        bool isBold = false);
+    void updateLabels();
+    static juce::Colour getStatusColour(bool isLoaded);
+    static juce::String getFileNameOrFallback(const juce::File& file,
+                                              bool isLoaded,
+                                              const juce::String& fallback);
+    static juce::String getPathOrFallback(const juce::File& file,
+                                          bool isLoaded,
+                                          const juce::String& fallback);
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(FileStatusCard)
+};

--- a/Source/Include/Components/FileStatusCard.h
+++ b/Source/Include/Components/FileStatusCard.h
@@ -7,10 +7,21 @@
 
 class FileStatusCard : public juce::Component {
    public:
+    enum class Status {
+        Empty,
+        Loaded,
+        Warning,
+        Error
+    };
+
     struct Options {
         juce::String title;
         juce::String loadButtonText;
         juce::String unloadButtonText{"Unload"};
+        juce::String emptyStatusText{"Not loaded"};
+        juce::String loadedStatusText{"Loaded"};
+        juce::String warningStatusText{"Warning"};
+        juce::String errorStatusText{"Missing"};
         juce::String emptyFileText;
         juce::String emptyPathText;
         ProfilerStyle::Theme loadButtonTheme = ProfilerStyle::Theme::Dark;
@@ -21,6 +32,7 @@ class FileStatusCard : public juce::Component {
     ~FileStatusCard() override = default;
 
     void setFileState(bool isLoaded, const juce::File& file);
+    void setFileState(Status status, const juce::File& file);
 
     std::function<void()> onLoadClicked;
     std::function<void()> onUnloadClicked;
@@ -37,7 +49,7 @@ class FileStatusCard : public juce::Component {
     juce::Label _fileLabel;
     juce::Label _pathLabel;
     juce::File _file;
-    bool _isLoaded = false;
+    Status _status = Status::Empty;
 
     void configureLabel(juce::Label& label,
                         const juce::String& text,
@@ -46,12 +58,15 @@ class FileStatusCard : public juce::Component {
                         juce::Justification justification = juce::Justification::centredLeft,
                         bool isBold = false);
     void updateLabels();
-    static juce::Colour getStatusColour(bool isLoaded);
+    bool isLoaded() const noexcept;
+    bool canUnload() const noexcept;
+    juce::String getStatusText() const;
+    static juce::Colour getStatusColour(Status status);
     static juce::String getFileNameOrFallback(const juce::File& file,
-                                              bool isLoaded,
+                                              Status status,
                                               const juce::String& fallback);
     static juce::String getPathOrFallback(const juce::File& file,
-                                          bool isLoaded,
+                                          Status status,
                                           const juce::String& fallback);
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(FileStatusCard)

--- a/Source/Include/Modules/FileAssetsModule.h
+++ b/Source/Include/Modules/FileAssetsModule.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <JuceHeader.h>
+
+#include "Components/FileStatusCard.h"
+
+class FileAssetsModule : public juce::Component {
+   public:
+    struct FileSlot {
+        FileStatusCard::Options cardOptions;
+        juce::String chooserTitle;
+        juce::String filePattern;
+        std::function<bool(const juce::File&)> loadFile;
+        std::function<void()> unloadFile;
+        std::function<bool()> isLoaded;
+        std::function<juce::File()> getCurrentFile;
+    };
+
+    FileAssetsModule(juce::String title,
+                     juce::String summary,
+                     std::vector<FileSlot> fileSlots);
+    ~FileAssetsModule() override = default;
+
+    void refreshFileState();
+
+    void paint(juce::Graphics& g) override;
+    void resized() override;
+
+   private:
+    juce::String _title;
+    juce::String _summary;
+    std::vector<FileSlot> _fileSlots;
+    std::vector<std::unique_ptr<FileStatusCard>> _cards;
+    juce::Label _titleLabel;
+    juce::Label _summaryLabel;
+    std::unique_ptr<juce::FileChooser> _fileChooser;
+
+    void configureHeaderLabel(juce::Label& label,
+                              const juce::String& text,
+                              float fontSize,
+                              juce::Colour textColour,
+                              bool isBold = false);
+    void chooseFile(size_t slotIndex);
+    void unloadFile(size_t slotIndex);
+    int getColumnCount(int availableWidth) const;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(FileAssetsModule)
+};

--- a/Source/Include/Modules/FileAssetsModule.h
+++ b/Source/Include/Modules/FileAssetsModule.h
@@ -3,6 +3,7 @@
 #include <JuceHeader.h>
 
 #include "Components/FileStatusCard.h"
+#include "Components/NotificationBanner.h"
 
 class FileAssetsModule : public juce::Component {
    public:
@@ -33,6 +34,8 @@ class FileAssetsModule : public juce::Component {
     std::vector<std::unique_ptr<FileStatusCard>> _cards;
     juce::Label _titleLabel;
     juce::Label _summaryLabel;
+    NotificationBanner _notificationBanner;
+    juce::String _currentIssueMessage;
     std::unique_ptr<juce::FileChooser> _fileChooser;
 
     void configureHeaderLabel(juce::Label& label,
@@ -42,7 +45,11 @@ class FileAssetsModule : public juce::Component {
                               bool isBold = false);
     void chooseFile(size_t slotIndex);
     void unloadFile(size_t slotIndex);
+    void showIssue(const juce::String& message, NotificationBanner::Type type);
+    void clearIssue();
     int getColumnCount(int availableWidth) const;
+    static FileStatusCard::Status getStatusForFile(bool isLoaded,
+                                                   const juce::File& file);
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(FileAssetsModule)
 };

--- a/Source/Include/Modules/UtilityBarModule.h
+++ b/Source/Include/Modules/UtilityBarModule.h
@@ -35,6 +35,7 @@ class UtilityBarModule : public juce::Component,
 
     void resetAllParameters();
     void resetParametersToDefaults();
+    void resetLoadedFiles();
     void refreshProfileMenu();
     void restoreLastUsedProfile();
     void selectProfileFromMenu();

--- a/Source/Include/Modules/UtilityBarModule.h
+++ b/Source/Include/Modules/UtilityBarModule.h
@@ -17,6 +17,7 @@ class UtilityBarModule : public juce::Component,
     void resized() override;
 
     std::function<void()> onExportClicked;
+    std::function<void(const juce::String&)> onResetCompleted;
 
    private:
     ProfilerAudioProcessor& _audioProcessor;
@@ -33,7 +34,7 @@ class UtilityBarModule : public juce::Component,
 
     bool _isUpdatingProfileMenu = false;
 
-    void resetAllParameters();
+    juce::String resetAllParameters();
     void resetParametersToDefaults();
     void resetLoadedFiles();
     void refreshProfileMenu();

--- a/Source/Include/PluginProcessor.h
+++ b/Source/Include/PluginProcessor.h
@@ -56,6 +56,13 @@ class ProfilerAudioProcessor : public juce::AudioProcessor {
     // Loading the Impulse responce file
     void loadIRFile();
     bool loadIRFile(const juce::File& file);
+    void unloadIRFile();
+    bool loadAmpFile(const juce::File& file);
+    void unloadAmpFile();
+    bool isIRLoaded() const noexcept;
+    bool isAmpFileLoaded() const noexcept;
+    juce::File getCurrentIRFile() const;
+    juce::File getCurrentAmpFile() const;
     bool applyProfile(int profileIndex, juce::String* errorMessage = nullptr);
     void startAmpProfiling();
     void startGainAnalysis();
@@ -127,6 +134,7 @@ class ProfilerAudioProcessor : public juce::AudioProcessor {
 
     // Is ir loaded bool
     bool _irLoaded = false;
+    juce::File _currentIRFile;
 
     // Convolver object
     juce::dsp::Convolution _convolver;
@@ -134,6 +142,8 @@ class ProfilerAudioProcessor : public juce::AudioProcessor {
     //================================= Amp load ====================================
     std::vector<float> _ampLUT;
     bool _ampLoaded = true;
+    bool _ampFileLoaded = false;
+    juce::File _currentAmpFile;
 
     AmpProcessor _ampStage;
 

--- a/Source/Include/PluginProcessor.h
+++ b/Source/Include/PluginProcessor.h
@@ -64,6 +64,8 @@ class ProfilerAudioProcessor : public juce::AudioProcessor {
     juce::File getCurrentIRFile() const;
     juce::File getCurrentAmpFile() const;
     bool applyProfile(int profileIndex, juce::String* errorMessage = nullptr);
+    juce::String getAppliedProfileId() const;
+    void clearAppliedProfile();
     void startAmpProfiling();
     void startGainAnalysis();
     ProfileManager& getProfileManager() noexcept;
@@ -119,6 +121,7 @@ class ProfilerAudioProcessor : public juce::AudioProcessor {
     std::atomic<float>* _isEqEnabledParam{nullptr};
 
     ProfileManager _profileManager;
+    juce::String _appliedProfileId;
 
     void updateEqCoefficients();
 

--- a/Source/Include/PluginProcessor.h
+++ b/Source/Include/PluginProcessor.h
@@ -64,6 +64,7 @@ class ProfilerAudioProcessor : public juce::AudioProcessor {
     juce::File getCurrentIRFile() const;
     juce::File getCurrentAmpFile() const;
     bool applyProfile(int profileIndex, juce::String* errorMessage = nullptr);
+    void syncLoadedFilesWithCurrentProfile();
     juce::String getAppliedProfileId() const;
     void clearAppliedProfile();
     void startAmpProfiling();
@@ -124,6 +125,7 @@ class ProfilerAudioProcessor : public juce::AudioProcessor {
     juce::String _appliedProfileId;
 
     void updateEqCoefficients();
+    void applyProfileFileValues(const juce::NamedValueSet& values);
 
     //==============================================================================
     juce::AudioProcessorValueTreeState::ParameterLayout createParameterLayout();

--- a/Source/Include/Views/CloneView.h
+++ b/Source/Include/Views/CloneView.h
@@ -6,7 +6,8 @@
 
 class ProfilerAudioProcessor;
 
-class CloneView : public juce::Component {
+class CloneView : public juce::Component,
+                  private juce::ChangeListener {
    public:
     CloneView(ProfilerAudioProcessor& p);
     ~CloneView();
@@ -15,5 +16,8 @@ class CloneView : public juce::Component {
     void resized() override;
 
    private:
+    ProfilerAudioProcessor& _audioProcessor;
     FileAssetsModule _fileAssetsModule;
+
+    void changeListenerCallback(juce::ChangeBroadcaster* source) override;
 };

--- a/Source/Include/Views/CloneView.h
+++ b/Source/Include/Views/CloneView.h
@@ -1,7 +1,10 @@
+#pragma once
+
 #include <JuceHeader.h>
 
-#include "Components/CustomTextButton.h"
-#include "PluginProcessor.h"
+#include "Modules/FileAssetsModule.h"
+
+class ProfilerAudioProcessor;
 
 class CloneView : public juce::Component {
    public:
@@ -12,9 +15,5 @@ class CloneView : public juce::Component {
     void resized() override;
 
    private:
-    ProfilerAudioProcessor& _audioProcessor;
-
-    CustomTextButton _sweepButton{"Start Sweep"};
-    CustomTextButton _loadIRButton{"Load IR"};
-    CustomTextButton _loadAmpButton{"Load Amp"};
+    FileAssetsModule _fileAssetsModule;
 };

--- a/Source/Src/Components/FileStatusCard.cpp
+++ b/Source/Src/Components/FileStatusCard.cpp
@@ -1,0 +1,164 @@
+#include "Components/FileStatusCard.h"
+
+FileStatusCard::FileStatusCard(Options options)
+    : _options(std::move(options)),
+      _loadButton(_options.loadButtonText, _options.loadButtonTheme),
+      _unloadButton(_options.unloadButtonText, _options.unloadButtonTheme) {
+    configureLabel(_titleLabel,
+                   _options.title,
+                   16.0f,
+                   ProfilerStyle::Colors::white,
+                   juce::Justification::centredLeft,
+                   true);
+    configureLabel(_statusLabel,
+                   {},
+                   13.0f,
+                   ProfilerStyle::Colors::white.withAlpha(0.58f),
+                   juce::Justification::centredRight,
+                   true);
+    configureLabel(_fileLabel,
+                   {},
+                   16.0f,
+                   ProfilerStyle::Colors::white,
+                   juce::Justification::centredLeft,
+                   true);
+    configureLabel(_pathLabel,
+                   {},
+                   13.0f,
+                   ProfilerStyle::Colors::white.withAlpha(0.62f));
+
+    addAndMakeVisible(_titleLabel);
+    addAndMakeVisible(_statusLabel);
+    addAndMakeVisible(_fileLabel);
+    addAndMakeVisible(_pathLabel);
+    addAndMakeVisible(_loadButton);
+    addAndMakeVisible(_unloadButton);
+
+    _loadButton.onClick = [this]() {
+        if (onLoadClicked) {
+            onLoadClicked();
+        }
+    };
+    _unloadButton.onClick = [this]() {
+        if (onUnloadClicked) {
+            onUnloadClicked();
+        }
+    };
+
+    updateLabels();
+}
+
+void FileStatusCard::setFileState(bool isLoaded, const juce::File& file) {
+    _isLoaded = isLoaded;
+    _file = file;
+    updateLabels();
+    resized();
+    repaint();
+}
+
+void FileStatusCard::paint(juce::Graphics& g) {
+    const auto card = getLocalBounds().toFloat();
+
+    g.setGradientFill(ProfilerStyle::Gradients::vertical(
+        card,
+        ProfilerStyle::Colors::lighterGrey.withAlpha(0.78f),
+        ProfilerStyle::Colors::darkerGrey.withAlpha(0.72f),
+        0.85f));
+    g.fillRoundedRectangle(card, 5.0f);
+
+    g.setColour(getStatusColour(_isLoaded).withAlpha(_isLoaded ? 0.75f : 0.28f));
+    g.fillRoundedRectangle(card.withWidth(4.0f), 2.0f);
+
+    g.setColour(ProfilerStyle::Colors::lightestGrey.withAlpha(0.34f));
+    g.drawRoundedRectangle(card, 5.0f, 1.0f);
+}
+
+void FileStatusCard::resized() {
+    auto content = getLocalBounds().reduced(16);
+    auto titleRow = content.removeFromTop(24);
+
+    _statusLabel.setBounds(titleRow.removeFromRight(96));
+    _titleLabel.setBounds(titleRow);
+
+    content.removeFromTop(14);
+    _fileLabel.setBounds(content.removeFromTop(28));
+
+    content.removeFromTop(4);
+    _pathLabel.setBounds(content.removeFromTop(24));
+
+    auto buttonArea = content.removeFromBottom(38);
+    const auto loadButtonWidth = juce::jmin(148, buttonArea.getWidth());
+
+    if (_isLoaded) {
+        constexpr auto gap = 10;
+        const auto unloadButtonWidth = juce::jmin(112, juce::jmax(0, buttonArea.getWidth() - loadButtonWidth - gap));
+        _loadButton.setBounds(buttonArea.removeFromLeft(loadButtonWidth));
+        buttonArea.removeFromLeft(gap);
+        _unloadButton.setBounds(buttonArea.removeFromLeft(unloadButtonWidth));
+    } else {
+        _loadButton.setBounds(buttonArea.withWidth(loadButtonWidth));
+        _unloadButton.setBounds({});
+    }
+}
+
+void FileStatusCard::configureLabel(juce::Label& label,
+                                    const juce::String& text,
+                                    float fontSize,
+                                    juce::Colour textColour,
+                                    juce::Justification justification,
+                                    bool isBold) {
+    auto font = juce::Font(juce::FontOptions(fontSize));
+    font.setBold(isBold);
+
+    label.setText(text, juce::dontSendNotification);
+    label.setFont(font);
+    label.setJustificationType(justification);
+    label.setColour(juce::Label::textColourId, textColour);
+    label.setMinimumHorizontalScale(0.7f);
+    label.setInterceptsMouseClicks(false, false);
+}
+
+void FileStatusCard::updateLabels() {
+    _statusLabel.setText(_isLoaded ? "Loaded" : "Not loaded",
+                         juce::dontSendNotification);
+    _statusLabel.setColour(juce::Label::textColourId, getStatusColour(_isLoaded));
+
+    _fileLabel.setText(getFileNameOrFallback(_file, _isLoaded, _options.emptyFileText),
+                       juce::dontSendNotification);
+    _pathLabel.setText(getPathOrFallback(_file, _isLoaded, _options.emptyPathText),
+                       juce::dontSendNotification);
+
+    const auto tooltip = _isLoaded ? _file.getFullPathName() : juce::String{};
+    _fileLabel.setTooltip(tooltip);
+    _pathLabel.setTooltip(tooltip);
+
+    _unloadButton.setEnabled(_isLoaded);
+    _unloadButton.setVisible(_isLoaded);
+}
+
+juce::Colour FileStatusCard::getStatusColour(bool isLoaded) {
+    return isLoaded ? juce::Colour(0xff38d17a)
+                    : ProfilerStyle::Colors::white.withAlpha(0.58f);
+}
+
+juce::String FileStatusCard::getFileNameOrFallback(const juce::File& file,
+                                                   bool isLoaded,
+                                                   const juce::String& fallback) {
+    if (!isLoaded) {
+        return fallback;
+    }
+
+    const auto fileName = file.getFileName();
+    return fileName.isNotEmpty() ? fileName : fallback;
+}
+
+juce::String FileStatusCard::getPathOrFallback(const juce::File& file,
+                                               bool isLoaded,
+                                               const juce::String& fallback) {
+    if (!isLoaded) {
+        return fallback;
+    }
+
+    const auto path = file.getFullPathName();
+    return path.isNotEmpty() ? path : fallback;
+}

--- a/Source/Src/Components/FileStatusCard.cpp
+++ b/Source/Src/Components/FileStatusCard.cpp
@@ -49,7 +49,11 @@ FileStatusCard::FileStatusCard(Options options)
 }
 
 void FileStatusCard::setFileState(bool isLoaded, const juce::File& file) {
-    _isLoaded = isLoaded;
+    setFileState(isLoaded ? Status::Loaded : Status::Empty, file);
+}
+
+void FileStatusCard::setFileState(Status status, const juce::File& file) {
+    _status = status;
     _file = file;
     updateLabels();
     resized();
@@ -58,6 +62,7 @@ void FileStatusCard::setFileState(bool isLoaded, const juce::File& file) {
 
 void FileStatusCard::paint(juce::Graphics& g) {
     const auto card = getLocalBounds().toFloat();
+    const auto accent = getStatusColour(_status);
 
     g.setGradientFill(ProfilerStyle::Gradients::vertical(
         card,
@@ -66,10 +71,10 @@ void FileStatusCard::paint(juce::Graphics& g) {
         0.85f));
     g.fillRoundedRectangle(card, 5.0f);
 
-    g.setColour(getStatusColour(_isLoaded).withAlpha(_isLoaded ? 0.75f : 0.28f));
+    g.setColour(accent.withAlpha(_status == Status::Empty ? 0.28f : 0.75f));
     g.fillRoundedRectangle(card.withWidth(4.0f), 2.0f);
 
-    g.setColour(ProfilerStyle::Colors::lightestGrey.withAlpha(0.34f));
+    g.setColour(accent.withAlpha(_status == Status::Empty ? 0.34f : 0.5f));
     g.drawRoundedRectangle(card, 5.0f, 1.0f);
 }
 
@@ -89,7 +94,7 @@ void FileStatusCard::resized() {
     auto buttonArea = content.removeFromBottom(38);
     const auto loadButtonWidth = juce::jmin(148, buttonArea.getWidth());
 
-    if (_isLoaded) {
+    if (canUnload()) {
         constexpr auto gap = 10;
         const auto unloadButtonWidth = juce::jmin(112, juce::jmax(0, buttonArea.getWidth() - loadButtonWidth - gap));
         _loadButton.setBounds(buttonArea.removeFromLeft(loadButtonWidth));
@@ -119,32 +124,62 @@ void FileStatusCard::configureLabel(juce::Label& label,
 }
 
 void FileStatusCard::updateLabels() {
-    _statusLabel.setText(_isLoaded ? "Loaded" : "Not loaded",
-                         juce::dontSendNotification);
-    _statusLabel.setColour(juce::Label::textColourId, getStatusColour(_isLoaded));
+    _statusLabel.setText(getStatusText(), juce::dontSendNotification);
+    _statusLabel.setColour(juce::Label::textColourId, getStatusColour(_status));
 
-    _fileLabel.setText(getFileNameOrFallback(_file, _isLoaded, _options.emptyFileText),
+    _fileLabel.setText(getFileNameOrFallback(_file, _status, _options.emptyFileText),
                        juce::dontSendNotification);
-    _pathLabel.setText(getPathOrFallback(_file, _isLoaded, _options.emptyPathText),
+    _pathLabel.setText(getPathOrFallback(_file, _status, _options.emptyPathText),
                        juce::dontSendNotification);
 
-    const auto tooltip = _isLoaded ? _file.getFullPathName() : juce::String{};
+    const auto tooltip = _status == Status::Empty ? juce::String{} : _file.getFullPathName();
     _fileLabel.setTooltip(tooltip);
     _pathLabel.setTooltip(tooltip);
 
-    _unloadButton.setEnabled(_isLoaded);
-    _unloadButton.setVisible(_isLoaded);
+    _unloadButton.setEnabled(canUnload());
+    _unloadButton.setVisible(canUnload());
 }
 
-juce::Colour FileStatusCard::getStatusColour(bool isLoaded) {
-    return isLoaded ? juce::Colour(0xff38d17a)
-                    : ProfilerStyle::Colors::white.withAlpha(0.58f);
+bool FileStatusCard::isLoaded() const noexcept {
+    return _status == Status::Loaded;
+}
+
+bool FileStatusCard::canUnload() const noexcept {
+    return _status != Status::Empty;
+}
+
+juce::String FileStatusCard::getStatusText() const {
+    switch (_status) {
+        case Status::Loaded:
+            return _options.loadedStatusText;
+        case Status::Warning:
+            return _options.warningStatusText;
+        case Status::Error:
+            return _options.errorStatusText;
+        case Status::Empty:
+        default:
+            return _options.emptyStatusText;
+    }
+}
+
+juce::Colour FileStatusCard::getStatusColour(Status status) {
+    switch (status) {
+        case Status::Loaded:
+            return juce::Colour(0xff38d17a);
+        case Status::Warning:
+            return juce::Colour(0xffffb020);
+        case Status::Error:
+            return juce::Colour(0xffff4d4f);
+        case Status::Empty:
+        default:
+            return ProfilerStyle::Colors::white.withAlpha(0.58f);
+    }
 }
 
 juce::String FileStatusCard::getFileNameOrFallback(const juce::File& file,
-                                                   bool isLoaded,
+                                                   Status status,
                                                    const juce::String& fallback) {
-    if (!isLoaded) {
+    if (status == Status::Empty) {
         return fallback;
     }
 
@@ -153,9 +188,9 @@ juce::String FileStatusCard::getFileNameOrFallback(const juce::File& file,
 }
 
 juce::String FileStatusCard::getPathOrFallback(const juce::File& file,
-                                               bool isLoaded,
+                                               Status status,
                                                const juce::String& fallback) {
-    if (!isLoaded) {
+    if (status == Status::Empty) {
         return fallback;
     }
 

--- a/Source/Src/Modules/FileAssetsModule.cpp
+++ b/Source/Src/Modules/FileAssetsModule.cpp
@@ -34,15 +34,35 @@ FileAssetsModule::FileAssetsModule(juce::String title,
         _cards.push_back(std::move(card));
     }
 
+    addChildComponent(_notificationBanner);
     refreshFileState();
 }
 
 void FileAssetsModule::refreshFileState() {
+    juce::String issueMessage;
+    auto issueType = NotificationBanner::Type::Info;
+
     for (size_t index = 0; index < _cards.size(); ++index) {
         const auto& slot = _fileSlots[index];
         const auto isLoaded = slot.isLoaded ? slot.isLoaded() : false;
         const auto file = slot.getCurrentFile ? slot.getCurrentFile() : juce::File{};
-        _cards[index]->setFileState(isLoaded, file);
+        const auto status = getStatusForFile(isLoaded, file);
+
+        _cards[index]->setFileState(status, file);
+
+        if (issueMessage.isEmpty() && status == FileStatusCard::Status::Error) {
+            issueMessage = slot.cardOptions.title + " file does not exist: " + file.getFullPathName();
+            issueType = NotificationBanner::Type::Error;
+        } else if (issueMessage.isEmpty() && status == FileStatusCard::Status::Warning) {
+            issueMessage = slot.cardOptions.title + " file is referenced but not loaded: " + file.getFullPathName();
+            issueType = NotificationBanner::Type::Warning;
+        }
+    }
+
+    if (issueMessage.isNotEmpty()) {
+        showIssue(issueMessage, issueType);
+    } else {
+        clearIssue();
     }
 }
 
@@ -77,6 +97,14 @@ void FileAssetsModule::resized() {
 
         _cards[static_cast<size_t>(index)]->setBounds(x, y, cardWidth, cardHeight);
     }
+
+    const auto bannerWidth = juce::jmin(_notificationBanner.getIdealWidth(),
+                                        juce::jmax(220, getWidth() - 50));
+    _notificationBanner.setBounds(getLocalBounds()
+                                      .withSizeKeepingCentre(bannerWidth,
+                                                             _notificationBanner.getIdealHeight())
+                                      .withRightX(getWidth() - 25)
+                                      .withY(25));
 }
 
 void FileAssetsModule::configureHeaderLabel(juce::Label& label,
@@ -117,7 +145,10 @@ void FileAssetsModule::chooseFile(size_t slotIndex) {
                                   const auto file = chooser.getResult();
                                   const auto& selectedSlot = safeThis->_fileSlots[slotIndex];
                                   if (file.existsAsFile() && selectedSlot.loadFile) {
-                                      selectedSlot.loadFile(file);
+                                      if (!selectedSlot.loadFile(file)) {
+                                          safeThis->showIssue("Could not load file: " + file.getFullPathName(),
+                                                              NotificationBanner::Type::Error);
+                                      }
                                   }
 
                                   safeThis->refreshFileState();
@@ -137,6 +168,24 @@ void FileAssetsModule::unloadFile(size_t slotIndex) {
     refreshFileState();
 }
 
+void FileAssetsModule::showIssue(const juce::String& message,
+                                 NotificationBanner::Type type) {
+    if (_currentIssueMessage == message && _notificationBanner.isVisible()) {
+        return;
+    }
+
+    _currentIssueMessage = message;
+    _notificationBanner.clearAction();
+    _notificationBanner.showMessage(message, type, 0);
+    resized();
+}
+
+void FileAssetsModule::clearIssue() {
+    _currentIssueMessage.clear();
+    _notificationBanner.clearAction();
+    _notificationBanner.dismiss();
+}
+
 int FileAssetsModule::getColumnCount(int availableWidth) const {
     const auto cardCount = static_cast<int>(_cards.size());
     if (cardCount <= 1 || availableWidth < 520) {
@@ -148,4 +197,18 @@ int FileAssetsModule::getColumnCount(int availableWidth) const {
     }
 
     return juce::jmin(cardCount, 3);
+}
+
+FileStatusCard::Status FileAssetsModule::getStatusForFile(bool isLoaded,
+                                                          const juce::File& file) {
+    if (isLoaded) {
+        return FileStatusCard::Status::Loaded;
+    }
+
+    if (file.getFullPathName().trim().isEmpty()) {
+        return FileStatusCard::Status::Empty;
+    }
+
+    return file.existsAsFile() ? FileStatusCard::Status::Warning
+                               : FileStatusCard::Status::Error;
 }

--- a/Source/Src/Modules/FileAssetsModule.cpp
+++ b/Source/Src/Modules/FileAssetsModule.cpp
@@ -1,0 +1,151 @@
+#include "Modules/FileAssetsModule.h"
+
+#include "Stylesheet.h"
+
+FileAssetsModule::FileAssetsModule(juce::String title,
+                                   juce::String summary,
+                                   std::vector<FileSlot> fileSlots)
+    : _title(std::move(title)),
+      _summary(std::move(summary)),
+      _fileSlots(std::move(fileSlots)) {
+    configureHeaderLabel(_titleLabel,
+                         _title,
+                         24.0f,
+                         ProfilerStyle::Colors::white,
+                         true);
+    configureHeaderLabel(_summaryLabel,
+                         _summary,
+                         14.0f,
+                         ProfilerStyle::Colors::white.withAlpha(0.72f));
+
+    addAndMakeVisible(_titleLabel);
+    addAndMakeVisible(_summaryLabel);
+
+    for (size_t index = 0; index < _fileSlots.size(); ++index) {
+        auto card = std::make_unique<FileStatusCard>(_fileSlots[index].cardOptions);
+        card->onLoadClicked = [this, index]() {
+            chooseFile(index);
+        };
+        card->onUnloadClicked = [this, index]() {
+            unloadFile(index);
+        };
+
+        addAndMakeVisible(*card);
+        _cards.push_back(std::move(card));
+    }
+
+    refreshFileState();
+}
+
+void FileAssetsModule::refreshFileState() {
+    for (size_t index = 0; index < _cards.size(); ++index) {
+        const auto& slot = _fileSlots[index];
+        const auto isLoaded = slot.isLoaded ? slot.isLoaded() : false;
+        const auto file = slot.getCurrentFile ? slot.getCurrentFile() : juce::File{};
+        _cards[index]->setFileState(isLoaded, file);
+    }
+}
+
+void FileAssetsModule::paint(juce::Graphics& /*g*/) {
+}
+
+void FileAssetsModule::resized() {
+    auto area = getLocalBounds().reduced(24);
+
+    auto headerArea = area.removeFromTop(58);
+    _titleLabel.setBounds(headerArea.removeFromTop(30));
+    _summaryLabel.setBounds(headerArea.removeFromTop(24));
+
+    area.removeFromTop(10);
+
+    const auto cardCount = static_cast<int>(_cards.size());
+    if (cardCount == 0) {
+        return;
+    }
+
+    constexpr auto gap = 14;
+    const auto columns = getColumnCount(area.getWidth());
+    const auto rows = (cardCount + columns - 1) / columns;
+    const auto cardWidth = (area.getWidth() - (columns - 1) * gap) / columns;
+    const auto cardHeight = (area.getHeight() - (rows - 1) * gap) / rows;
+
+    for (int index = 0; index < cardCount; ++index) {
+        const auto column = index % columns;
+        const auto row = index / columns;
+        const auto x = area.getX() + column * (cardWidth + gap);
+        const auto y = area.getY() + row * (cardHeight + gap);
+
+        _cards[static_cast<size_t>(index)]->setBounds(x, y, cardWidth, cardHeight);
+    }
+}
+
+void FileAssetsModule::configureHeaderLabel(juce::Label& label,
+                                            const juce::String& text,
+                                            float fontSize,
+                                            juce::Colour textColour,
+                                            bool isBold) {
+    auto font = juce::Font(juce::FontOptions(fontSize));
+    font.setBold(isBold);
+
+    label.setText(text, juce::dontSendNotification);
+    label.setFont(font);
+    label.setJustificationType(juce::Justification::centredLeft);
+    label.setColour(juce::Label::textColourId, textColour);
+    label.setMinimumHorizontalScale(0.7f);
+    label.setInterceptsMouseClicks(false, false);
+}
+
+void FileAssetsModule::chooseFile(size_t slotIndex) {
+    if (slotIndex >= _fileSlots.size()) {
+        return;
+    }
+
+    const auto& slot = _fileSlots[slotIndex];
+    _fileChooser = std::make_unique<juce::FileChooser>(
+        slot.chooserTitle,
+        juce::File{},
+        slot.filePattern);
+
+    const juce::Component::SafePointer<FileAssetsModule> safeThis(this);
+    _fileChooser->launchAsync(juce::FileBrowserComponent::openMode |
+                                  juce::FileBrowserComponent::canSelectFiles,
+                              [safeThis, slotIndex](const juce::FileChooser& chooser) {
+                                  if (safeThis == nullptr || slotIndex >= safeThis->_fileSlots.size()) {
+                                      return;
+                                  }
+
+                                  const auto file = chooser.getResult();
+                                  const auto& selectedSlot = safeThis->_fileSlots[slotIndex];
+                                  if (file.existsAsFile() && selectedSlot.loadFile) {
+                                      selectedSlot.loadFile(file);
+                                  }
+
+                                  safeThis->refreshFileState();
+                                  safeThis->_fileChooser.reset();
+                              });
+}
+
+void FileAssetsModule::unloadFile(size_t slotIndex) {
+    if (slotIndex >= _fileSlots.size()) {
+        return;
+    }
+
+    if (_fileSlots[slotIndex].unloadFile) {
+        _fileSlots[slotIndex].unloadFile();
+    }
+
+    refreshFileState();
+}
+
+int FileAssetsModule::getColumnCount(int availableWidth) const {
+    const auto cardCount = static_cast<int>(_cards.size());
+    if (cardCount <= 1 || availableWidth < 520) {
+        return 1;
+    }
+
+    if (availableWidth < 760) {
+        return juce::jmin(cardCount, 2);
+    }
+
+    return juce::jmin(cardCount, 3);
+}

--- a/Source/Src/Modules/UtilityBarModule.cpp
+++ b/Source/Src/Modules/UtilityBarModule.cpp
@@ -24,7 +24,10 @@ UtilityBarModule::UtilityBarModule(ProfilerAudioProcessor& processor)
     };
 
     _resetButton.onClick = [this]() {
-        resetAllParameters();
+        const auto message = resetAllParameters();
+        if (onResetCompleted) {
+            onResetCompleted(message);
+        }
     };
 
     _exportButton.onClick = [this]() {
@@ -63,7 +66,7 @@ void UtilityBarModule::resized() {
     _eqSwitch.setBounds(eqSwitchArea);
 }
 
-void UtilityBarModule::resetAllParameters() {
+juce::String UtilityBarModule::resetAllParameters() {
     auto& profileManager = _audioProcessor.getProfileManager();
     const auto currentProfileIndex = profileManager.getCurrentProfileIndex();
 
@@ -71,7 +74,7 @@ void UtilityBarModule::resetAllParameters() {
         juce::String errorMessage;
         if (_audioProcessor.applyProfile(currentProfileIndex, &errorMessage)) {
             refreshProfileMenu();
-            return;
+            return "Current profile restored";
         }
     }
 
@@ -82,6 +85,8 @@ void UtilityBarModule::resetAllParameters() {
         profileManager.clearCurrentProfile();
         refreshProfileMenu();
     }
+
+    return "Default settings restored";
 }
 
 void UtilityBarModule::resetParametersToDefaults() {

--- a/Source/Src/Modules/UtilityBarModule.cpp
+++ b/Source/Src/Modules/UtilityBarModule.cpp
@@ -70,16 +70,18 @@ void UtilityBarModule::resetAllParameters() {
     if (currentProfileIndex >= 0) {
         juce::String errorMessage;
         if (_audioProcessor.applyProfile(currentProfileIndex, &errorMessage)) {
+            refreshProfileMenu();
             return;
         }
     }
+
+    resetParametersToDefaults();
+    resetLoadedFiles();
 
     if (profileManager.getCurrentProfileId().isNotEmpty()) {
         profileManager.clearCurrentProfile();
         refreshProfileMenu();
     }
-
-    resetParametersToDefaults();
 }
 
 void UtilityBarModule::resetParametersToDefaults() {
@@ -99,6 +101,12 @@ void UtilityBarModule::resetParametersToDefaults() {
     resetParam("treble");
     resetParam("isMute");
     resetParam("isEqEnabled");
+}
+
+void UtilityBarModule::resetLoadedFiles() {
+    _audioProcessor.unloadIRFile();
+    _audioProcessor.unloadAmpFile();
+    _audioProcessor.clearAppliedProfile();
 }
 
 void UtilityBarModule::refreshProfileMenu() {
@@ -130,9 +138,16 @@ void UtilityBarModule::restoreLastUsedProfile() {
 
     const auto currentProfileIndex = profileManager.getCurrentProfileIndex();
     if (currentProfileIndex < 0) {
-        profileManager.clearCurrentProfile();
         resetParametersToDefaults();
+        resetLoadedFiles();
+        profileManager.clearCurrentProfile();
         refreshProfileMenu();
+        return;
+    }
+
+    if (_audioProcessor.getAppliedProfileId() == profileManager.getCurrentProfileId()) {
+        const juce::ScopedValueSetter<bool> updatingProfileMenu(_isUpdatingProfileMenu, true);
+        _profilMenu.setSelectedId(currentProfileIndex + 2, juce::dontSendNotification);
         return;
     }
 
@@ -141,8 +156,9 @@ void UtilityBarModule::restoreLastUsedProfile() {
         const juce::ScopedValueSetter<bool> updatingProfileMenu(_isUpdatingProfileMenu, true);
         _profilMenu.setSelectedId(currentProfileIndex + 2, juce::dontSendNotification);
     } else {
-        profileManager.clearCurrentProfile();
         resetParametersToDefaults();
+        resetLoadedFiles();
+        profileManager.clearCurrentProfile();
         refreshProfileMenu();
     }
 }
@@ -155,8 +171,9 @@ void UtilityBarModule::selectProfileFromMenu() {
     auto& profileManager = _audioProcessor.getProfileManager();
     const auto selectedId = _profilMenu.getSelectedId();
     if (selectedId == 1) {
-        profileManager.clearCurrentProfile();
         resetParametersToDefaults();
+        resetLoadedFiles();
+        profileManager.clearCurrentProfile();
         return;
     }
 

--- a/Source/Src/PluginProcessor.cpp
+++ b/Source/Src/PluginProcessor.cpp
@@ -440,6 +440,7 @@ bool ProfilerAudioProcessor::applyProfile(int profileIndex, juce::String* errorM
         return false;
     }
 
+    const auto* profile = _profileManager.getProfile(profileIndex);
     const auto values = _profileManager.getProfileValues(profileIndex);
     if (const auto* irPath = values.getVarPointer("irPath")) {
         const auto irPathText = irPath->toString().trim();
@@ -448,7 +449,12 @@ bool ProfilerAudioProcessor::applyProfile(int profileIndex, juce::String* errorM
             unloadIRFile();
         } else if (irFile.existsAsFile()) {
             loadIRFile(irFile);
+        } else {
+            unloadIRFile();
+            _currentIRFile = irFile;
         }
+    } else {
+        unloadIRFile();
     }
 
     if (const auto* ampPath = values.getVarPointer("ampPath")) {
@@ -458,10 +464,24 @@ bool ProfilerAudioProcessor::applyProfile(int profileIndex, juce::String* errorM
             unloadAmpFile();
         } else if (ampFile.existsAsFile()) {
             loadAmpFile(ampFile);
+        } else {
+            unloadAmpFile();
+            _currentAmpFile = ampFile;
         }
+    } else {
+        unloadAmpFile();
     }
 
+    _appliedProfileId = profile != nullptr ? profile->id : juce::String{};
     return true;
+}
+
+juce::String ProfilerAudioProcessor::getAppliedProfileId() const {
+    return _appliedProfileId;
+}
+
+void ProfilerAudioProcessor::clearAppliedProfile() {
+    _appliedProfileId.clear();
 }
 
 void ProfilerAudioProcessor::startAmpProfiling() {

--- a/Source/Src/PluginProcessor.cpp
+++ b/Source/Src/PluginProcessor.cpp
@@ -442,6 +442,28 @@ bool ProfilerAudioProcessor::applyProfile(int profileIndex, juce::String* errorM
 
     const auto* profile = _profileManager.getProfile(profileIndex);
     const auto values = _profileManager.getProfileValues(profileIndex);
+    applyProfileFileValues(values);
+
+    _appliedProfileId = profile != nullptr ? profile->id : juce::String{};
+    return true;
+}
+
+void ProfilerAudioProcessor::syncLoadedFilesWithCurrentProfile() {
+    const auto currentProfileIndex = _profileManager.getCurrentProfileIndex();
+    const auto* profile = _profileManager.getProfile(currentProfileIndex);
+
+    if (profile == nullptr) {
+        unloadIRFile();
+        unloadAmpFile();
+        clearAppliedProfile();
+        return;
+    }
+
+    applyProfileFileValues(_profileManager.getProfileValues(currentProfileIndex));
+    _appliedProfileId = profile->id;
+}
+
+void ProfilerAudioProcessor::applyProfileFileValues(const juce::NamedValueSet& values) {
     if (const auto* irPath = values.getVarPointer("irPath")) {
         const auto irPathText = irPath->toString().trim();
         const auto irFile = juce::File(irPathText);
@@ -471,9 +493,6 @@ bool ProfilerAudioProcessor::applyProfile(int profileIndex, juce::String* errorM
     } else {
         unloadAmpFile();
     }
-
-    _appliedProfileId = profile != nullptr ? profile->id : juce::String{};
-    return true;
 }
 
 juce::String ProfilerAudioProcessor::getAppliedProfileId() const {

--- a/Source/Src/PluginProcessor.cpp
+++ b/Source/Src/PluginProcessor.cpp
@@ -400,7 +400,7 @@ bool ProfilerAudioProcessor::loadIRFile(const juce::File& file) {
 
 void ProfilerAudioProcessor::unloadIRFile() {
     _irLoaded = false;
-    _currentIRFile = {};
+    _currentIRFile = juce::File{};
     _convolver.reset();
 }
 
@@ -416,7 +416,7 @@ bool ProfilerAudioProcessor::loadAmpFile(const juce::File& file) {
 
 void ProfilerAudioProcessor::unloadAmpFile() {
     _ampFileLoaded = false;
-    _currentAmpFile = {};
+    _currentAmpFile = juce::File{};
 }
 
 bool ProfilerAudioProcessor::isIRLoaded() const noexcept {

--- a/Source/Src/PluginProcessor.cpp
+++ b/Source/Src/PluginProcessor.cpp
@@ -394,7 +394,45 @@ bool ProfilerAudioProcessor::loadIRFile(const juce::File& file) {
                                    juce::dsp::Convolution::Trim::no,
                                    0);
     _irLoaded = true;
+    _currentIRFile = file;
     return true;
+}
+
+void ProfilerAudioProcessor::unloadIRFile() {
+    _irLoaded = false;
+    _currentIRFile = {};
+    _convolver.reset();
+}
+
+bool ProfilerAudioProcessor::loadAmpFile(const juce::File& file) {
+    if (!file.existsAsFile()) {
+        return false;
+    }
+
+    _currentAmpFile = file;
+    _ampFileLoaded = true;
+    return true;
+}
+
+void ProfilerAudioProcessor::unloadAmpFile() {
+    _ampFileLoaded = false;
+    _currentAmpFile = {};
+}
+
+bool ProfilerAudioProcessor::isIRLoaded() const noexcept {
+    return _irLoaded;
+}
+
+bool ProfilerAudioProcessor::isAmpFileLoaded() const noexcept {
+    return _ampFileLoaded;
+}
+
+juce::File ProfilerAudioProcessor::getCurrentIRFile() const {
+    return _currentIRFile;
+}
+
+juce::File ProfilerAudioProcessor::getCurrentAmpFile() const {
+    return _currentAmpFile;
 }
 
 bool ProfilerAudioProcessor::applyProfile(int profileIndex, juce::String* errorMessage) {
@@ -404,9 +442,22 @@ bool ProfilerAudioProcessor::applyProfile(int profileIndex, juce::String* errorM
 
     const auto values = _profileManager.getProfileValues(profileIndex);
     if (const auto* irPath = values.getVarPointer("irPath")) {
-        const auto irFile = juce::File(irPath->toString());
-        if (irFile.existsAsFile()) {
+        const auto irPathText = irPath->toString().trim();
+        const auto irFile = juce::File(irPathText);
+        if (irPathText.isEmpty()) {
+            unloadIRFile();
+        } else if (irFile.existsAsFile()) {
             loadIRFile(irFile);
+        }
+    }
+
+    if (const auto* ampPath = values.getVarPointer("ampPath")) {
+        const auto ampPathText = ampPath->toString().trim();
+        const auto ampFile = juce::File(ampPathText);
+        if (ampPathText.isEmpty()) {
+            unloadAmpFile();
+        } else if (ampFile.existsAsFile()) {
+            loadAmpFile(ampFile);
         }
     }
 

--- a/Source/Src/Views/CloneView.cpp
+++ b/Source/Src/Views/CloneView.cpp
@@ -1,23 +1,63 @@
 #include "Views/CloneView.h"
 
+#include "PluginProcessor.h"
 #include "Stylesheet.h"
 
+namespace {
+std::vector<FileAssetsModule::FileSlot> createCloneFileSlots(ProfilerAudioProcessor& processor) {
+    FileAssetsModule::FileSlot irSlot;
+    irSlot.cardOptions.title = "IR";
+    irSlot.cardOptions.loadButtonText = "Load IR";
+    irSlot.cardOptions.emptyFileText = "No IR file loaded";
+    irSlot.cardOptions.emptyPathText = "No IR path";
+    irSlot.cardOptions.loadButtonTheme = ProfilerStyle::Theme::Orange;
+    irSlot.chooserTitle = "Select an IR file";
+    irSlot.filePattern = "*.wav;*.aiff;*.aif;*.flac";
+    irSlot.loadFile = [&processor](const juce::File& file) {
+        return processor.loadIRFile(file);
+    };
+    irSlot.unloadFile = [&processor]() {
+        processor.unloadIRFile();
+    };
+    irSlot.isLoaded = [&processor]() {
+        return processor.isIRLoaded();
+    };
+    irSlot.getCurrentFile = [&processor]() {
+        return processor.getCurrentIRFile();
+    };
+
+    FileAssetsModule::FileSlot ampSlot;
+    ampSlot.cardOptions.title = "Amp";
+    ampSlot.cardOptions.loadButtonText = "Load Amp";
+    ampSlot.cardOptions.emptyFileText = "No amp file loaded";
+    ampSlot.cardOptions.emptyPathText = "No amp path";
+    ampSlot.chooserTitle = "Select an Amp file";
+    ampSlot.filePattern = "*.nam;*.json;*.txt";
+    ampSlot.loadFile = [&processor](const juce::File& file) {
+        return processor.loadAmpFile(file);
+    };
+    ampSlot.unloadFile = [&processor]() {
+        processor.unloadAmpFile();
+    };
+    ampSlot.isLoaded = [&processor]() {
+        return processor.isAmpFileLoaded();
+    };
+    ampSlot.getCurrentFile = [&processor]() {
+        return processor.getCurrentAmpFile();
+    };
+
+    std::vector<FileAssetsModule::FileSlot> slots;
+    slots.push_back(std::move(irSlot));
+    slots.push_back(std::move(ampSlot));
+    return slots;
+}
+}  // namespace
+
 CloneView::CloneView(ProfilerAudioProcessor& p)
-    : _audioProcessor(p) {
-    addAndMakeVisible(_sweepButton);
-    _sweepButton.onClick = [this]() {
-        _audioProcessor.startAmpProfiling();
-    };
-
-    addAndMakeVisible(_loadIRButton);
-    _loadIRButton.onClick = [this]() {
-        _audioProcessor.loadIRFile();
-    };
-
-    addAndMakeVisible(_loadAmpButton);
-    _loadAmpButton.onClick = [this]() {
-        _audioProcessor.startGainAnalysis();
-    };
+    : _fileAssetsModule("Clone Assets",
+                        "External clone files currently selected for the plugin.",
+                        createCloneFileSlots(p)) {
+    addAndMakeVisible(_fileAssetsModule);
 }
 
 CloneView::~CloneView() {
@@ -39,18 +79,5 @@ void CloneView::paint(juce::Graphics& g) {
 }
 
 void CloneView::resized() {
-    auto area = getLocalBounds().reduced(static_cast<int>(getWidth() * 0.1f));
-
-    float spacing = getWidth() * 0.01f;
-    float buttonWidth = (area.getWidth() - (spacing * 2)) / 3.0f;
-
-    float buttonHeight = buttonWidth;
-
-    auto rowArea = area.withHeight(static_cast<int>(buttonHeight)).withCentre(getLocalBounds().getCentre());
-
-    _sweepButton.setBounds(rowArea.removeFromLeft(static_cast<int>(buttonWidth)).toNearestInt());
-    rowArea.removeFromLeft(static_cast<int>(spacing));
-    _loadIRButton.setBounds(rowArea.removeFromLeft(static_cast<int>(buttonWidth)).toNearestInt());
-    rowArea.removeFromLeft(static_cast<int>(spacing));
-    _loadAmpButton.setBounds(rowArea.removeFromLeft(static_cast<int>(buttonWidth)).toNearestInt());
+    _fileAssetsModule.setBounds(getLocalBounds());
 }

--- a/Source/Src/Views/CloneView.cpp
+++ b/Source/Src/Views/CloneView.cpp
@@ -54,13 +54,16 @@ std::vector<FileAssetsModule::FileSlot> createCloneFileSlots(ProfilerAudioProces
 }  // namespace
 
 CloneView::CloneView(ProfilerAudioProcessor& p)
-    : _fileAssetsModule("Clone Assets",
+    : _audioProcessor(p),
+      _fileAssetsModule("Clone Assets",
                         "External clone files currently selected for the plugin.",
                         createCloneFileSlots(p)) {
     addAndMakeVisible(_fileAssetsModule);
+    _audioProcessor.getProfileManager().addChangeListener(this);
 }
 
 CloneView::~CloneView() {
+    _audioProcessor.getProfileManager().removeChangeListener(this);
     setLookAndFeel(nullptr);
 }
 
@@ -80,4 +83,10 @@ void CloneView::paint(juce::Graphics& g) {
 
 void CloneView::resized() {
     _fileAssetsModule.setBounds(getLocalBounds());
+}
+
+void CloneView::changeListenerCallback(juce::ChangeBroadcaster* source) {
+    if (source == &_audioProcessor.getProfileManager()) {
+        _fileAssetsModule.refreshFileState();
+    }
 }

--- a/Source/Src/Views/PlayView.cpp
+++ b/Source/Src/Views/PlayView.cpp
@@ -119,7 +119,13 @@ void PlayView::showExportProfilModule() {
     _notificationBanner.dismiss();
 
     const auto exportName = getDefaultExportName();
-    const auto values = _audioProcessor.getProfileManager().getCurrentProfileValues(exportName);
+    auto values = _audioProcessor.getProfileManager().getCurrentProfileValues(exportName);
+    values.set("irPath", _audioProcessor.isIRLoaded()
+                             ? _audioProcessor.getCurrentIRFile().getFullPathName()
+                             : juce::String{});
+    values.set("ampPath", _audioProcessor.isAmpFileLoaded()
+                              ? _audioProcessor.getCurrentAmpFile().getFullPathName()
+                              : juce::String{});
 
     _exportProfilModule.setExportValues(values, getDefaultExportFile(exportName));
     _contentMode = ContentMode::ExportProfil;

--- a/Source/Src/Views/PlayView.cpp
+++ b/Source/Src/Views/PlayView.cpp
@@ -29,6 +29,14 @@ PlayView::PlayView(ProfilerAudioProcessor& p)
         showExportProfilModule();
     };
 
+    _utilityBar.onResetCompleted = [this](const juce::String& message) {
+        _notificationBanner.clearAction();
+        _notificationBanner.showMessage(message,
+                                        NotificationBanner::Type::Success,
+                                        5000);
+        resized();
+    };
+
     _exportProfilModule.onExportClicked = [this](const juce::NamedValueSet& values,
                                                  const juce::File& destinationFile) {
         exportProfil(values, destinationFile);

--- a/Source/Src/Views/ProfilView.cpp
+++ b/Source/Src/Views/ProfilView.cpp
@@ -33,7 +33,17 @@ ProfilView::ProfilView(ProfilerAudioProcessor& p)
     };
     _editProfilModule.onSaveClicked = [this](int profileNumber, const juce::NamedValueSet& values) {
         juce::String errorMessage;
-        if (_audioProcessor.getProfileManager().updateProfile(profileNumber - 1, values, &errorMessage)) {
+        auto& profileManager = _audioProcessor.getProfileManager();
+        const auto profileIndex = profileNumber - 1;
+        const auto* profile = profileManager.getProfile(profileIndex);
+        const auto isCurrentProfile = profile != nullptr &&
+                                      profile->id == profileManager.getCurrentProfileId();
+
+        if (profileManager.updateProfile(profileIndex, values, &errorMessage)) {
+            if (isCurrentProfile) {
+                _audioProcessor.syncLoadedFilesWithCurrentProfile();
+            }
+
             refreshProfileGrid();
             _notificationBanner.clearAction();
             _notificationBanner.showMessage("Profile saved successfully",
@@ -158,7 +168,17 @@ void ProfilView::showDeleteProfileModal(int profileNumber) {
 
 void ProfilView::deleteProfile(int profileNumber) {
     juce::String errorMessage;
-    if (_audioProcessor.getProfileManager().deleteProfile(profileNumber - 1, &errorMessage)) {
+    auto& profileManager = _audioProcessor.getProfileManager();
+    const auto profileIndex = profileNumber - 1;
+    const auto* profile = profileManager.getProfile(profileIndex);
+    const auto isCurrentProfile = profile != nullptr &&
+                                  profile->id == profileManager.getCurrentProfileId();
+
+    if (profileManager.deleteProfile(profileIndex, &errorMessage)) {
+        if (isCurrentProfile) {
+            _audioProcessor.syncLoadedFilesWithCurrentProfile();
+        }
+
         refreshProfileGrid();
         _notificationBanner.clearAction();
         _notificationBanner.showMessage("Profile deleted successfully",


### PR DESCRIPTION
## Summary

Reworks the Clone view around externally managed clone files instead of the old sweep workflow. The Clone view now shows IR and Amp file state, supports loading/unloading files, reports missing referenced files, and stays synchronized with the current profile behavior.

## Changes

- Replace the Clone view sweep/start controls with reusable file asset UI.
- Add `FileStatusCard` and `FileAssetsModule` for generic file loading, unloading, status display, and missing-file warnings.
- Track currently loaded IR and Amp files in `ProfilerAudioProcessor`.
- Load IR/Amp file paths when the current profile changes.
- Preserve temporary Clone file changes while switching between Play and Clone views.
- Reset now restores files and parameters from the current profile, or defaults when no profile is active.
- Add a reset success notification in the Play view.
- Include currently loaded IR/Amp files when exporting a profile.
- Sync Clone files when the current profile is saved or deleted.
- Register the new Clone file UI sources in CMake.

## Testing

- Ran `.\install.bat build` successfully.
- `git diff --check` passed, with only CRLF notices.